### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,35 @@
 
 Thanks for stopping by! Looking to find out how you can contribute to **Palaeoverse**? You have come to the right place! 
 
-We very much appreciate and encourage community contributions, and if there is anything that is unclear within this guide, please let us know by logging an [issues](https://github.com/palaeoverse/community/issues) so we can improve it.
+We very much appreciate and encourage community contributions, and if there is anything that is unclear within this guide, please let us know by logging an [issue](https://github.com/palaeoverse/resources/issues) so we can improve it.
 
-## How to contribute to Palaeoverse software
+There are multiple ways to contribute to the **Palaeoverse**. This page will go through all of them, starting from the easiest one and progressively increasing the difficulty level.
 
-### Issues
+## Joining the community on Zulip
 
-Tasks that need working on are logged as 'issues' within the respective repository e.g. current ([*palaeoverse* issues](https://github.com/palaeoverse/palaeoverse/issues)) can be found here. 
+TODO: add proper link to zulip
 
-If you want to get involved with contributing to our packages but don't know where to start, this is a great place to identify what tasks need working on. You can also contribute by logging issues that you have encountered such as typos, bugs, feature requests, etc. 
+TODO: possibly tweak the "anyone can join"
 
-We aim to maintain a list of 'Good First Issues' specifically for new contributors to our packages. Feel free to find one of the unclaimed 'Good First Issues' that interests you, claim it by adding a comment to it, and jump in!
+[Zulip]() is where the community gathers to exchange and share useful resources, whether it be papers, job offers, tutorials, or simply to have interesting discussions. Anyone can join this community, and participating there is the easiest way to contribute to the Palaeoverse.
+
+The remaining sections will focus on the software components of the Palaeoverse.
+
+## Participating in existing issues or opening new ones
+
+Tasks that need working on are logged as 'issues' within the respective repository (e.g. current *palaeoverse* issues can be found [here](https://github.com/palaeoverse/palaeoverse/issues)). Participating in the discussion of existing issues or opening new issues for bug reports or feature requests are a great way to start contributing to a package. 
+
+## Contributing to code or documentation
+
+If you want to get involved with contributing some code or documentation to our packages but don't know where to start, you can look for issues labelled 'Good First Issues'. These issues are reserved specifically for new contributors to our packages. Feel free to find one of the unclaimed 'Good First Issues' that interests you, claim it by adding a comment to it, and jump in! Note that you can also work on an issue without this label. 
+
+No matter which issue you want to address, it is good to add a message in the issue to let people know that you are working on it.
 
 ### Minor changes
 
-You can fix typos, spelling mistakes, or grammatical errors in the documentation directly on GitHub, provided it is done so in the source file. This means you’ll need to edit `roxygen2` comments in the `.R` file, not the `.Rd` file.
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly on GitHub. 
+
+Note that fixing typos in the function documentation (those in the "Reference" page on the package website) requires editing the source in the corresponding `.R` file and then run `devtools::document()`. *Do not manually edit an `.Rd` file in `man/`*.
 
 ### Substantial changes
 
@@ -24,27 +38,37 @@ If you would like to make a substantial change, you should first file an issue a
 
 ### Contribution workflow (pull request process)
 
+The workflow below requires you to have basic knowledge of git and Github. If this is not the case, you can reach out to one of the [core team members](https://palaeoverse.org/#about-us) via email and they can make a pull request on your behalf. However, you will be expected to respond to any reviewer comments on GitHub (see below).
+
+This describes the process to make a pull request:
+
 1. You (the contributor) should fork the repository (e.g. for the [palaeoverse](https://github.com/palaeoverse/palaeoverse) R package)
-2. Clone the desired repository to your personal computer
-3. Before changes are made, you should create a new git branch (i.e. not the main branch)
-4. Keep your branch in sync
-5. Commit your changes (make sure your commit message is concise)
-6. Push your commits to your forked repository
-7. When your changes are complete, you should submit your changes for merging via a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) (“PR”) on GitHub
+1. Clone the desired repository to your personal computer
+1. Before changes are made, you should create a new git branch (i.e. not the main branch)
+1. Make your changes
+1. Commit your changes (make sure your commit message is concise)
+1. Push your commits to your forked repository
+1. When your changes are complete, you should submit them for merging via a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) (“PR”) on GitHub
 
 Note that a complete pull request should include a succinct description ([see function template](PULL_REQUEST_TEMPLATE.md)) of what the code changes do, proper documentation (via [roxygen2](https://roxygen2.r-lib.org)), and unit tests (via `testthat`). Only the description is required for the initial pull request and code review (see below), but pull requests will not be merged until they contain complete documentation and tests.
 
-If you are not comfortable with git/GitHub, you can reach out to one of the [core team](https://palaeoverse.org/#about-us) via email and they can make a pull request on your behalf. However, you will be expected to respond to any reviewer comments on GitHub (see below).
+You also have to ensure that you follow our [AI policy]().
 
-If you don't feel comfortable implementing changes yourself, you can submit a bug report or feature request as a GitHub issue in the proper repository (e.g. for [palaeoverse issues](https://github.com/palaeoverse/palaeoverse/issues)).
+TODO: add a link to the AI policy
+
+
+### The life of a pull request
+
+All pull requests must be reviewed by two members of the Palaeoverse ([core team](https://palaeoverse.org/#about-us) before merging. The review process will ensure that contributions 1) meet the standards and expectations as described above, 2) successfully perform the functions that they claim to perform, and 3) don't break any other parts of the codebase.
+
+Submitting a pull request for one of Palaeoverse's R packages will automatically initiate an [R CMD check](https://r-pkgs.org/check.html), [formatting check](https://posit-dev.github.io/air/), [lintr check](https://lintr.r-lib.org/index.html), and [test coverage check](https://covr.r-lib.org/) via GitHub Actions. While these checks will conduct some automatic review to ensure the package has not been broken by the new code and that the code matches the style guide (see above), a manual review is still required before the pull request can be merged.
+
+Reviewers may have questions while reviewing your pull request. You are expected to respond to any of these questions via GitHub. If fixes and/or changes are required, you are expected to make these changes. If the required changes are minor enough, reviewers may make them for you, but this should not be expected. If you have any questions or lack the background to make the required changes, you should work with the reviewer to determine a plan of attack.
 
 ## Code review
 
-All pull requests must be reviewed by two core developers of the Palaeoverse ([core team](https://palaeoverse.org/#about-us) before merging. The review process will ensure that contributions 1) meet the standards and expectations as described above, 2) successfully perform the functions that they claim to perform, and 3) don't break any other parts of the codebase.
+TODO: This is not the same as addressing the code review of maintainers
 
-Submitting a pull request for one of Palaeoverse's R packages will automatically initiate an [R CMD check](https://r-pkgs.org/check.html), [lintr check](https://lintr.r-lib.org/index.html), and [test coverage check](https://covr.r-lib.org/) via GitHub Actions. While these checks will conduct some automatic review to ensure the package has not been broken by the new code and that the code matches the style guide (see above), a manual review is still required before the pull request can be merged.
-
-Reviewers may have questions while reviewing your pull request. You are expected to respond to any of these questions via GitHub. If fixes and/or changes are required, you are expected to make these changes. If the required changes are minor enough, reviewers may make them for you, but this should not be expected. If you have any questions or lack the background to make the required changes, you should work with the reviewer to determine a plan of attack.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Still very early draft. I follow the order of contributions (from easy to hard) we had defined in WP2 DP1:

1. Reporting an issue or a feature request on Zulip.
1. Commenting on an existing issue on Github.
1. Opening a new issue on Github (this may be incentivized in error messages in our packages).
1. Contributing code/docs.
1. Doing code review.

Part of #11
